### PR TITLE
Upgrade python3-urllib3 to address urllib3 CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN rpmbuild -ba /root/rpmbuild/SPECS/openvpn.spec
 
 FROM registry.access.redhat.com/ubi8:latest
 RUN dnf -y update && dnf -y install cpio lzo socat stunnel && dnf clean all
+RUN dnf upgrade -y python3-urllib3 && dnf clean all
 COPY --from=builder /root/rpmbuild/RPMS/x86_64/pkcs11-helper-1* ./
 COPY --from=builder /root/rpmbuild/RPMS/x86_64/openvpn-2* ./
 RUN bash -c 'rpm2cpio < pkcs11-helper-1* | cpio -ivd'


### PR DESCRIPTION
## Summary

- Upgrades `python3-urllib3` RPM in the final `ubi8` stage to address 4 CVEs:
  - CVE-2025-66418 (fixed in urllib3 2.6.0)
  - CVE-2025-66471 (fixed in urllib3 2.6.0)
  - CVE-2026-21441 (fixed in urllib3 2.6.3)
  - CVE-2026-44431 (fixed in urllib3 2.7.0)
- `dnf upgrade -y python3-urllib3` will pull the latest available patched RPM from the UBI repos at build time

## Test plan
- [ ] Verify the built image contains urllib3 >= 2.7.0
- [ ] Confirm no regressions in openvpn functionality